### PR TITLE
chore: fix one typo cause unarchive zip not throwing errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -547,9 +547,9 @@ exports.start_attachment = function (
       plugin.unarchive_recursive(connection, fn, filename, (error, files) => {
         txn.notes.attachment_count--;
         cleanup();
-        if (err) {
+        if (error) {
           connection.logerror(plugin, error.message);
-          if (err.message === 'maximum archive depth exceeded') {
+          if (error.message === 'maximum archive depth exceeded') {
             txn.notes.attachment_result = [
               DENY,
               'Message contains nested archives exceeding the maximum depth',


### PR DESCRIPTION
As there's a small typo in variable name, unarchive zip won't throwing any errors.